### PR TITLE
Add register_global_constant operations

### DIFF
--- a/dags/resources/stages/load/schemas/register_global_constant_operations.json
+++ b/dags/resources/stages/load/schemas/register_global_constant_operations.json
@@ -1,0 +1,114 @@
+[
+     {
+        "name": "level",
+        "type": "INTEGER",
+        "description": "Block level",
+        "mode": "REQUIRED"
+    },
+    {
+        "name": "timestamp",
+        "type": "TIMESTAMP",
+        "description": "Block timestamp",
+        "mode": "REQUIRED"
+    },
+    {
+        "name": "block_hash",
+        "type": "STRING",
+        "description": "Block hash",
+        "mode": "REQUIRED"
+    },
+    {
+        "name": "branch",
+        "type": "STRING",
+        "description": "Branch"
+    },
+    {
+        "name": "signature",
+        "type": "STRING",
+        "description": "Operation signature"
+    },
+    {
+        "name": "operation_hash",
+        "type": "STRING",
+        "description": "Operation hash",
+        "mode": "REQUIRED"
+    },
+    {
+        "name": "operation_group_index",
+        "type": "INTEGER",
+        "description": "Operation group index",
+        "mode": "REQUIRED"
+    },
+    {
+        "name": "operation_index",
+        "type": "INTEGER",
+        "description": "Operation index",
+        "mode": "REQUIRED"
+    },
+    {
+        "name": "content_index",
+        "type": "INTEGER",
+        "description": "Operation content index",
+        "mode": "REQUIRED"
+    },
+    {
+        "name": "internal_operation_index",
+        "type": "INTEGER",
+        "description": "If operation is found in internal operation results, this field contains internal operation index"
+    },
+    {
+        "name": "source",
+        "type": "STRING",
+        "description": ""
+    },
+    {
+        "name": "destination",
+        "type": "STRING",
+        "description": ""
+    },
+    {
+        "name": "fee",
+        "type": "INTEGER",
+        "description": ""
+    },
+    {
+        "name": "amount",
+        "type": "INTEGER",
+        "description": ""
+    },
+    {
+        "name": "counter",
+        "type": "INTEGER",
+        "description": ""
+    },
+    {
+        "name": "gas_limit",
+        "type": "INTEGER",
+        "description": ""
+    },
+    {
+        "name": "storage_limit",
+        "type": "INTEGER",
+        "description": ""
+    },
+    {
+        "name": "status",
+        "type": "STRING",
+        "description": ""
+    },
+    {
+        "name": "consumed_gas",
+        "type": "INTEGER",
+        "description": ""
+    },
+    {
+        "name": "storage_size",
+        "type": "INTEGER",
+        "description": ""
+    },
+    {
+        "name": "value",
+        "type": "STRING",
+        "description": ""
+    }
+]


### PR DESCRIPTION
Add `register_global_constant` operation, a rare operation added in late 2021 that has only occurred twice but resulted in two missing days that could not be synced.

https://www.marigold.dev/post/introducing-global-constants